### PR TITLE
add support for include and exclude options for better control over the transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 09/23/2020
+
+- Added `include` and `exclude` configuration option to support cases that users do not want(or only want) to transform specific environment variables
+
 # 09/22/2020
 
 - Improved readability by utilizing built-in `utils.functions.listAll`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is when your function code is evaluated when a request was received. The fo
 
 **Problem**
 
-You may have noticed that for the available environment variables at Runtime variables is only a subset of that in build time.
+You may have noticed that the available environment variables at Runtime is only a subset of that in build time.
 
 That is a common source of confusion for many people, see discussions over [here](https://community.netlify.com/t/support-guide-using-environment-variables-on-netlify-correctly/267).
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ To install, add the following lines to your `netlify.toml` file:
 package = "netlify-plugin-inline-functions-env"
 ```
 
-## Debugging
+## More Options
+
+### Debugging
 
 You can turn on verbose for debugging purpose by providing plugin inputs.
 
@@ -97,7 +99,7 @@ package = "netlify-plugin-inline-functions-env"
 
 > Be careful with verbose mode, as it will print the files with the replaced env variables
 
-## Configuring build event
+### Configuring build event
 
 If you are using TypeScript, or processing your code in other ways you may want to choose `onBuild`
 
@@ -110,6 +112,24 @@ package = "netlify-plugin-inline-functions-env"
 
 Default value is `onPreBuild`. It's also been tested to work with `onBuild`
 The values for buildEvent can be found [here](https://docs.netlify.com/configure-builds/build-plugins/create-plugins/#plug-in-to-build-events)
+
+### Conditional Transformation
+
+If you are using libraries such as [dotenv-defaults](https://github.com/mrsteele/dotenv-defaults), you may want to limit or skip the transformation for certain environment variables.
+
+```toml
+[[plugins]]
+package = "netlify-plugin-inline-functions-env"
+  [plugins.inputs]
+  exclude = ["DO_NOT_TRANSFORM_ME", "DO_NOT_TRANSFORM_ME_2"]
+```
+
+```toml
+[[plugins]]
+package = "netlify-plugin-inline-functions-env"
+  [plugins.inputs]
+  include = ["ONLY_TRANSFORM_ME", "ONLY_TRANSFORM_ME_2"]
+```
 
 ## Gotchas
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,7 @@ inputs:
     description: Turn on more logs for debugging
   - name: buildEvent
     description: Choose which netlify build event to trigger on. onPreBuild by default (https://docs.netlify.com/configure-builds/build-plugins/create-plugins/#plug-in-to-build-events)
+  - name: include
+    description: Only tranform whitelisted environment variables
+  - name: exclude
+    description: Do not tranform selected environment variables


### PR DESCRIPTION
Adds control over which env variables to transform.
Is a potential solution to fix #11 

@dac09 please help review

@tysonmatanich please verify whether this can be a general solution for your requested support for .env.defaults.