### PR TITLE
Babel: Disable loading project-wide config

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ async function inlineEnv(path, options = {}, verbose = false) {
   console.log('inlining', path)
 
   const transformed = await babel.transformFileAsync(path, {
+    configFile: false,
     plugins: [babel.createConfigItem([inlinePlugin, options])],
     retainLines: true,
   })


### PR DESCRIPTION
If this plugin is used in a project with a Babel config (eg. `babel.config.js`), [those settings will be used when inlining function variables](https://babeljs.io/docs/en/config-files#project-wide-configuration) as a project-wide config.

This can lead to unintended transforms being applied to functions eg. functions being transpiled in a browser context and then failing on execution due to missing polyfills.

Let's disable the project-wide config when using Babel to inline environment variables.