### PR TITLE
Make error for missing functions more verbose

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ async function processFiles({ inputs, utils }) {
   try {
     netlifyFunctions = await utils.functions.listAll()
   } catch (functionMissingErr) {
+    console.log(functionMissingErr) // functions can be there but there is an error when executing
     return utils.build.failBuild(
       'Failed to inline function files because netlify function folder was not configured or pointed to a wrong folder, please check your configuration'
     )


### PR DESCRIPTION
The exception raised by `utils.functions.listAll()` might not be related to the directory missing but to functions compiling with an error